### PR TITLE
Fix a small typo in "Thanks to students"

### DIFF
--- a/index.Rmd
+++ b/index.Rmd
@@ -148,7 +148,7 @@ Each chapter of the book contains the following sections:
 The content of this book is based on hundreds of conversations I have had with (mostly) Computer Science students and their employers since 2012. I've also had significant support from academic colleagues in the Department of Computer Science  ([\@csmcr](https://twitter.com/csmcr)) and support staff at the University of Manchester. ([\@ManUniCareers](https://twitter.com/ManUniCareers), [\@alumniUoM](https://twitter.com/alumniUoM), [\@OfficialUoM](https://twitter.com/OfficialUoM))
 
 ### Thanks to students {#students}
-First and foremost, I'd like to thank all the students who have helped with this book, both directly and directly. I can't name you all but if you have studied some flavour of Computer Science as an undergraduate at the University of Manchester since 2012, there's a good chance you have contributed to this book. Thank you!
+First and foremost, I'd like to thank all the students who have helped with this book, both directly and indirectly. I can't name you all but if you have studied some flavour of Computer Science as an undergraduate at the University of Manchester since 2012, there's a good chance you have contributed to this book. Thank you!
 
 ```{r echo = FALSE, fig.align = "center", out.width = "100%", fig.cap = "(ref:captionbbcsofa)"}
 knitr::include_graphics("images/bbcbreakfastsofa.png")


### PR DESCRIPTION
Adding a small change to the sentence "First and foremost, I'd like to thank all the students who have helped with this book, both directly and directly." Assuming directly is not repeated twice on purpose, changing one of them to indirectly.